### PR TITLE
Fix exception when decoding OIDServiceDiscovery with secure coding enabled

### DIFF
--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -185,8 +185,9 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
   }
 
-  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClass:[OIDServiceDiscovery class]
-                                                                  forKey:kDiscoveryDocumentKey];
+  NSSet *discoveryClasses = [NSSet setWithObjects:[NSArray class], [OIDServiceDiscovery class], nil];
+  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:discoveryClasses
+                                                                    forKey:kDiscoveryDocumentKey];
 
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint


### PR DESCRIPTION
We were getting this error when unarchiving the OIDAuthState using iOS 11+'s archive API:
```objc
*** Terminating app due to uncaught exception 'NSInvalidUnarchiveOperationException', reason: 'value for key 'NS.objects' was of unexpected class 'NSArray (0x7fff86d72430) [/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]'. Allowed classes are '{(
    "OIDServiceDiscovery (0x1087ed430) [/Users/jmanik/Library/Developer/CoreSimulator/Devices/8647CEAA-8D10-4E3D-A49D-C4E9802358DD/data/Containers/Bundle/Application/2B4D01ED-7847-43A3-8B94-58A2D198D0CC/GuestCenter.app]"
)}'.'
```

The fix is to include NSArray as a secure decoding class option, and then the exception goes away.