### PR TITLE
chore(xcode13): RO-12404 Resolve Warning for Implicit Object Type Decoding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  spm-build-test:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build unit test target
+      run: swift build
+    - name: Run unit test target
+      run: swift test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,10 @@ name: tests
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:

--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -158,7 +158,6 @@
 		2DA8D82624C6190400FDFB34 /* OIDTVAuthorizationResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DA8D82424C6190300FDFB34 /* OIDTVAuthorizationResponseTests.m */; };
 		2DEB065624CA1D9300DF47E7 /* OIDTVTokenRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DEB065424CA1D9300DF47E7 /* OIDTVTokenRequest.h */; };
 		2DEB065724CA1D9300DF47E7 /* OIDTVTokenRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DEB065524CA1D9300DF47E7 /* OIDTVTokenRequest.m */; };
-		2DEB066124CF5CE000DF47E7 /* OIDTVTokenRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DEB066024CF5CE000DF47E7 /* OIDTVTokenRequestTests.m */; };
 		2DEB066224CF5CFB00DF47E7 /* OIDTVTokenRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DEB066024CF5CE000DF47E7 /* OIDTVTokenRequestTests.m */; };
 		340DAE571D5821A100EC285B /* OIDAuthorizationService+Mac.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAE261D581FE700EC285B /* OIDAuthorizationService+Mac.m */; };
 		340DAE581D5821A100EC285B /* OIDExternalUserAgentMac.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAE281D581FE700EC285B /* OIDExternalUserAgentMac.m */; };
@@ -2353,7 +2352,6 @@
 				340DAECB1D582DE100EC285B /* OIDAuthorizationService+IOS.m in Sources */,
 				341741E31C5D8243000EF209 /* OIDResponseTypes.m in Sources */,
 				341741E41C5D8243000EF209 /* OIDScopes.m in Sources */,
-				2DEB066124CF5CE000DF47E7 /* OIDTVTokenRequestTests.m in Sources */,
 				341741E71C5D8243000EF209 /* OIDServiceDiscovery.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
         tokenEndpoint:(NSURL *)tokenEndpoint
                issuer:(nullable NSURL *)issuer
  registrationEndpoint:(nullable NSURL *)registrationEndpoint
-   endSessionEndpoint:(nullable OIDServiceDiscovery *)endSessionEndpoint
+   endSessionEndpoint:(nullable NSURL *)endSessionEndpoint
     discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument {
 
   self = [super init];

--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -186,8 +186,9 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   NSSet *discoveryClasses = [NSSet setWithObjects:[NSArray class],
-                            [NSString class],
-                            [OIDServiceDiscovery class],
+                             [NSNumber class],
+                             [NSString class],
+                             [OIDServiceDiscovery class],
                              nil];
   OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:discoveryClasses
                                                                     forKey:kDiscoveryDocumentKey];

--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -185,8 +185,12 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
   }
 
-  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClass:[OIDServiceDiscovery class]
-                                                                  forKey:kDiscoveryDocumentKey];
+  NSSet *discoveryClasses = [NSSet setWithObjects:[NSArray class],
+                             [NSString class],
+                             [OIDServiceDiscovery class],
+                             nil];
+  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:discoveryClasses
+                                                                    forKey:kDiscoveryDocumentKey];
 
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint

--- a/Source/AppAuthCore/OIDServiceDiscovery.h
+++ b/Source/AppAuthCore/OIDServiceDiscovery.h
@@ -326,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! @internal
     @brief Unavailable. Please use @c initWithDictionary:error:, @c initWithJSON:error, or the
-        @c serviceDiscoveryWithURL:callback: factory method.
+        @c discoverServiceConfigurationForDiscoveryURL:callback: from @c OIDAuthorizationService.
  */
 - (nonnull instancetype)init NS_UNAVAILABLE;
 

--- a/UnitTests/AppAuthTV/OIDTVAuthorizationResponseTests.m
+++ b/UnitTests/AppAuthTV/OIDTVAuthorizationResponseTests.m
@@ -281,5 +281,3 @@ static int const kTestInterval = 5;
 }
 
 @end
-
-#pragma GCC diagnostic pop

--- a/UnitTests/OIDRPProfileCode.m
+++ b/UnitTests/OIDRPProfileCode.m
@@ -118,10 +118,12 @@ typedef void (^UserInfoCompletion)(OIDAuthState *_Nullable authState,
 @implementation OIDRPProfileCode
 
 - (void)setUp {
+  XCTSkip("Need to migrate to the new OpenID conformance testing system.");
   [super setUp];
 }
 
 - (void)tearDown {
+  XCTSkip("Need to migrate to the new OpenID conformance testing system.");
   [super tearDown];
   
   [self endCertificationTest];
@@ -264,6 +266,7 @@ typedef void (^UserInfoCompletion)(OIDAuthState *_Nullable authState,
 }
 
 - (void)testRP_response_type_code {
+  XCTSkip("Not working at the moment.");
   NSString *testName = @"rp-response_type-code";
   [self startCertificationTest:testName];
   [self codeFlowWithExchangeExpectSuccessForTest:testName];


### PR DESCRIPTION
This PR resolves two warnings related to implicit type decoding. As well as merges the latest from openid/master 

```
OpenTable[26597:1006254] [general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSString' (0x7fff86500530) [/Applications/Xcode 13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'OIDServiceDiscovery' (0x106ff8460) [/Users/afriedman/Library/Developer/CoreSimulator/Devices/E50300E6-FAE9-4D8C-9646-9C9F4AAA3DF8/data/Containers/Bundle/Application/FF00B823-B6CD-47F1-8044-94B04283D476/OpenTable.app]",
    "'NSArray' (0x7fff864da6d0) [/Applications/Xcode 13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.
```
and

```
OpenTable[26597:1006254] [general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSNumber' (0x7fff86501228) [/Applications/Xcode 13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'OIDServiceDiscovery' (0x106ff8460) [/Users/afriedman/Library/Developer/CoreSimulator/Devices/E50300E6-FAE9-4D8C-9646-9C9F4AAA3DF8/data/Containers/Bundle/Application/FF00B823-B6CD-47F1-8044-94B04283D476/OpenTable.app]",
    "'NSArray' (0x7fff864da6d0) [/Applications/Xcode 13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.
```